### PR TITLE
Handle error cause by start-line not found

### DIFF
--- a/src/content_scripts/Command.js
+++ b/src/content_scripts/Command.js
@@ -70,7 +70,13 @@ class Command {
     }
 
     await this.inArticleGotoPageBeginning();
-    await this.inArticleGotoArticleEnding();
+
+    try {
+      await this.inArticleGotoArticleEnding();
+    } catch (err) {
+      const message = '無法取得推文開始位置（以 ※ 文章網址 開頭之行）。';
+      throw (new Error(message));
+    }
 
     const collectedLines = await this.inArticleCollectPushLines();
 


### PR DESCRIPTION
修正因為發文者錯誤編輯導致無法找到推文起始位置的錯誤